### PR TITLE
Normalize Gemini model configuration

### DIFF
--- a/api/gemini.js
+++ b/api/gemini.js
@@ -1,3 +1,22 @@
+const DEFAULT_MODEL = "gemini-1.5-flash-latest";
+
+function normalizeModel(model) {
+  if (!model) {
+    return DEFAULT_MODEL;
+  }
+
+  const sanitized = model.trim();
+
+  if (!sanitized) {
+    return DEFAULT_MODEL;
+  }
+
+  const withoutPrefix = sanitized.replace(/^models\//i, "");
+  const withoutSuffix = withoutPrefix.replace(/:generateContent$/i, "");
+
+  return withoutSuffix || DEFAULT_MODEL;
+}
+
 export default async function handler(req, res) {
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method Not Allowed" });
@@ -9,20 +28,31 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: "Missing prompt in request body" });
   }
 
+  if (!process.env.GEMINI_API_KEY) {
+    return res
+      .status(500)
+      .json({ error: "Server misconfiguration: missing GEMINI_API_KEY" });
+  }
+
+  const model = normalizeModel(process.env.GEMINI_MODEL);
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${process.env.GEMINI_API_KEY}`;
+
   try {
-    const response = await fetch(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=" +
-        process.env.GEMINI_API_KEY,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          contents: [{ parts: [{ text: prompt }] }],
-        }),
-      }
-    );
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+      }),
+    });
 
     const data = await response.json();
+
+    if (!response.ok) {
+      const errorMessage = data?.error?.message || `Gemini API error ${response.status}`;
+      return res.status(response.status).json({ error: errorMessage });
+    }
+
     return res.status(200).json(data);
   } catch (error) {
     return res.status(500).json({ error: error.message });


### PR DESCRIPTION
## Summary
- sanitize the configured Gemini model to drop duplicate `models/` prefixes and `:generateContent` suffixes
- keep using the default flash model when the configuration is missing or only whitespace

## Testing
- node --check api/gemini.js

------
https://chatgpt.com/codex/tasks/task_e_68e0c27876e08321b4d66fafd6d04a39